### PR TITLE
ActiveSupport::BufferedLogger is deprecated use ActiveSupport::Logger instead

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require "serial_preference/has_preference_map"
 
 FIXTURES_DIR = File.join(File.dirname(__FILE__), "fixtures")
 config = YAML::load(IO.read(File.dirname(__FILE__) + '/database.yml'))
-ActiveRecord::Base.logger = ActiveSupport::BufferedLogger.new(File.dirname(__FILE__) + "/debug.log")
+ActiveRecord::Base.logger = ActiveSupport::Logger.new(File.dirname(__FILE__) + "/debug.log")
 ActiveRecord::Base.establish_connection(config['test'])
 
 RSpec.configure do |config|


### PR DESCRIPTION
http://edgeapi.rubyonrails.org/classes/ActiveSupport/BufferedLogger.html#method-c-_deprecation_warning