### PR TITLE
Upgraded rspec, Lock the version of ActiveRecord dependency to less than 4.2.0

### DIFF
--- a/serial_preference.gemspec
+++ b/serial_preference.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "activerecord", ">= 3.0.0"
 
   gem.add_development_dependency 'sqlite3'
+  gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency "shoulda"
 

--- a/serial_preference.gemspec
+++ b/serial_preference.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "activerecord", ">= 3.0.0", "< 4.2.0"
 
   gem.add_development_dependency 'sqlite3'
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec', ">= 3.0.0"
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency "shoulda"
 

--- a/serial_preference.gemspec
+++ b/serial_preference.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "activesupport", ">= 3.0.0"
-  gem.add_runtime_dependency "activerecord", ">= 3.0.0"
+  gem.add_runtime_dependency "activesupport", ">= 3.0.0", "< 4.2.0"
+  gem.add_runtime_dependency "activerecord", ">= 3.0.0", "< 4.2.0"
 
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec'

--- a/spec/has_preference_map_spec.rb
+++ b/spec/has_preference_map_spec.rb
@@ -23,15 +23,15 @@ describe SerialPreference::HasSerialPreferences do
 
   context "class methods behaviour" do
     it "should be possible to describe preference map thru preferences" do
-      DummyClass.respond_to?(:preferences).should be_true
+      DummyClass.respond_to?(:preferences).should be_truthy
     end
 
     it "should be possble to retrieve preference groups from class" do
-      DummyClass.respond_to?(:preference_groups).should be_true
+      DummyClass.respond_to?(:preference_groups).should be_truthy
     end
 
     it "should be possble to retrieve preference names from class" do
-      DummyClass.respond_to?(:preference_names).should be_true
+      DummyClass.respond_to?(:preference_names).should be_truthy
     end
   end
 
@@ -39,10 +39,10 @@ describe SerialPreference::HasSerialPreferences do
   context "should define accessors" do
     it "should have readers available" do
       d = DummyClass.new
-      d.respond_to?(:taxable).should be_true
-      d.respond_to?(:vat_no).should be_true
-      d.respond_to?(:max_invoice_items).should be_true
-      d.respond_to?(:income_ledger_id).should be_true
+      d.respond_to?(:taxable).should be_truthy
+      d.respond_to?(:vat_no).should be_truthy
+      d.respond_to?(:max_invoice_items).should be_truthy
+      d.respond_to?(:income_ledger_id).should be_truthy
     end
 
     it "should ensure that the readers returns the correct data" do
@@ -53,10 +53,10 @@ describe SerialPreference::HasSerialPreferences do
 
     it "should have writers available" do
       d = DummyClass.new
-      d.respond_to?(:taxable=).should be_true
-      d.respond_to?(:vat_no=).should be_true
-      d.respond_to?(:max_invoice_items=).should be_true
-      d.respond_to?(:income_ledger_id=).should be_true
+      d.respond_to?(:taxable=).should be_truthy
+      d.respond_to?(:vat_no=).should be_truthy
+      d.respond_to?(:max_invoice_items=).should be_truthy
+      d.respond_to?(:income_ledger_id=).should be_truthy
     end
 
     it "should ensure that the writer write the correct data" do

--- a/spec/preference_definition_spec.rb
+++ b/spec/preference_definition_spec.rb
@@ -8,7 +8,7 @@ describe SerialPreference::PreferenceDefinition do
 
   it "should have proper accessors" do
     [:data_type, :name, :default, :required, :field_type].each do |a|
-      @blank_pref.respond_to?(a).should be_true
+      @blank_pref.respond_to?(a).should be_truthy
     end
   end
 
@@ -69,7 +69,7 @@ describe SerialPreference::PreferenceDefinition do
       @blank_pref.default.should be_nil
     end
     it "should be false for required" do
-      @blank_pref.required.should be_false
+      @blank_pref.required.should be_falsy
     end
     it "should have string field_type" do
       @blank_pref.field_type.should eq(:string)
@@ -162,19 +162,19 @@ describe SerialPreference::PreferenceDefinition do
       end
       it "should report false for falsy values" do
         [nil,false].each do |falsy|
-          @preference.value(falsy).should be_false
+          @preference.value(falsy).should be_falsy
         end
       end
 
       it "should report false for false looking values" do
         [0,"0","false","FALSE","False","no","NO","No"].each do |falsy|
-          @preference.value(falsy).should be_false
+          @preference.value(falsy).should be_falsy
         end
       end
 
       it "should report true for truthy values" do
         ["yes",true,100,0.1,[],{}].each do |truthy_value|
-          @preference.value(truthy_value).should be_true
+          @preference.value(truthy_value).should be_truthy
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $:.unshift File.expand_path('..', __FILE__)
 $:.unshift File.expand_path('../../lib', __FILE__)
 require 'active_support/all'
 require 'active_record'
+require 'yaml'
 require 'rspec'
 require 'shoulda'
 require "serial_preference/version"


### PR DESCRIPTION
As there are some broken changes in ActiveRecord > 4.2.0 current version does not support them.
