### PR TITLE
Add Rails 4.2 support

### DIFF
--- a/lib/serial_preference/preference_definition.rb
+++ b/lib/serial_preference/preference_definition.rb
@@ -10,7 +10,7 @@ module SerialPreference
       self.name = name.to_s
       opts.assert_valid_keys(:data_type,:default,:required,:field_type)
       self.data_type = @type = opts[:data_type] || :string
-      @column = ActiveRecord::ConnectionAdapters::Column.new(name.to_s,opts[:default],@type.to_s)
+      @column = ActiveRecord::ConnectionAdapters::Column.new(name.to_s, opts[:default], column_type(@type))
       self.default = opts[:default]
       self.required = !!opts[:required]
       self.field_type = opts[:field_type]
@@ -79,5 +79,27 @@ module SerialPreference
       end
     end
 
+    def column_type(type)
+      if rails_42?
+        case type
+        when :boolean
+          ActiveRecord::Type::Boolean.new
+        when :integer
+          ActiveRecord::Type::Integer.new
+        when :float
+          ActiveRecord::Type::Float.new
+        when :decimal
+          ActiveRecord::Type::Decimal.new
+        else
+          ActiveRecord::Type::String.new
+        end
+      else
+        type.to_s
+      end
+    end
+
+    def rails_42?
+      ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR == 2
+    end
   end
 end

--- a/serial_preference.gemspec
+++ b/serial_preference.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "activesupport", ">= 3.0.0", "< 4.2.0"
-  gem.add_runtime_dependency "activerecord", ">= 3.0.0", "< 4.2.0"
+  gem.add_runtime_dependency "activesupport", ">= 3.0.0"
+  gem.add_runtime_dependency "activerecord", ">= 3.0.0"
 
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec', ">= 3.0.0"


### PR DESCRIPTION
After this
https://github.com/rails/rails/commit/0b682e4b05c8f58c77c655650af6638c483ac903
it's changed how you can define new columns.

Basically have to pass a type instead of string.

refs: #5 