### PR TITLE
bugfix: undefined method `[]' for nil:NilClass [WIP]

### DIFF
--- a/lib/serial_preference/has_preference_map.rb
+++ b/lib/serial_preference/has_preference_map.rb
@@ -38,7 +38,13 @@ module SerialPreference
 
           key = preference.name
           define_method("#{key}=") do |value|
-            write_preference_attribute(self.class._preferences_attribute,key,self.class.preference_definition(key).value(value))
+            if self.preferences.class != Hash
+              self.class.reset_column_information
+              self.preferences = {}
+              write_preference_attribute(self.class._preferences_attribute,key,self.class.preference_definition(key).value(value))
+            else
+              write_preference_attribute(self.class._preferences_attribute,key,self.class.preference_definition(key).value(value))
+            end
           end
 
           define_method(key) do


### PR DESCRIPTION
https://github.com/asanghi/serial_preference/issues/9

After adding preferences column using migration and also populate data using migration preferences column not updated with HashWithIndifferentAccess.new 

We need to reset the self.class.reset_column_information and set preferences as a Hash
Now preferences column able to write/store all preferences attributes